### PR TITLE
Allows use of a custom length function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,8 +52,8 @@ methods
 
 var wrap = require('wordwrap');
 
-wrap(stop), wrap(start, stop, params={mode:"soft"})
----------------------------------------------------
+wrap(stop), wrap(start, stop, params={mode:"soft", lengthFn: String.length})
+----------------------------------------------------------------------------
 
 Returns a function that takes a string and returns a new string.
 
@@ -63,6 +63,9 @@ Pad out lines with spaces out to column `start` and then wrap until column
 In "soft" mode, split chunks by `/(\S+\s+/` and don't break up chunks which are
 longer than `stop - start`, in "hard" mode, split chunks with `/\b/` and break
 up chunks longer than `stop - start`.
+
+If provided, a custom length function can be used in place of the default
+`String.length`.
 
 wrap.hard(start, stop)
 ----------------------

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var wordwrap = module.exports = function (start, stop, params) {
     
     if (!params) params = {};
     var mode = params.mode || 'soft';
+    var len = params.lengthFn || _len;
     var re = mode === 'hard' ? /\b/ : /(\S+\s+)/;
     
     return function (text) {
@@ -25,7 +26,7 @@ var wordwrap = module.exports = function (start, stop, params) {
             .split(re)
             .reduce(function (acc, x) {
                 if (mode === 'hard') {
-                    for (var i = 0; i < x.length; i += stop - start) {
+                    for (var i = 0; i < len(x); i += stop - start) {
                         acc.push(x.slice(i, i + stop - start));
                     }
                 }
@@ -40,7 +41,7 @@ var wordwrap = module.exports = function (start, stop, params) {
             var chunk = rawChunk.replace(/\t/g, '    ');
             
             var i = lines.length - 1;
-            if (lines[i].length + chunk.length > stop) {
+            if (len(lines[i]) + len(chunk) > stop) {
                 lines[i] = lines[i].replace(/\s+$/, '');
                 
                 chunk.split(/\n/).forEach(function (c) {
@@ -74,3 +75,7 @@ wordwrap.soft = wordwrap;
 wordwrap.hard = function (start, stop) {
     return wordwrap(start, stop, { mode : 'hard' });
 };
+
+function _len(x) {
+  return x.length;
+}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "test": "test"
   },
   "scripts": {
-    "test": "expresso"
+    "test": "tape test/**/*.js"
   },
   "devDependencies": {
+    "strip-ansi": "^3.0.0",
     "tape": "^4.0.0"
   },
   "license": "MIT",

--- a/test/ansi-colored.txt
+++ b/test/ansi-colored.txt
@@ -1,0 +1,16 @@
+Like most of my [1m[34mgeneration[39m[22m, [1m[2mI was brought up on the saying[1m[22m: 'Satan finds [31msome[39m
+mischief for [1m[34midle hands to[39m[22m do.' [1m[31mBeing a[39m[22m highly virtuous child, I believed [31mall[39m
+that I was [31mtold, and acquired[39m a conscience which has [31mkept[39m me working hard down
+to the [31mpresent[39m moment. But [31malthough my conscience[39m has controlled my actions, my
+opinions have undergone a revolution. I think that there is far too much work
+done in the world, that immense harm is caused by the belief that work is
+virtuous, and that what needs to be preached in modern industrial countries is
+quite different from what always has been preached. Everyone knows the story of
+the traveler in Naples who saw twelve beggars lying in the sun (it was before
+the d[31mays of[39m Mussolini), and o[31mffere[39md a li[31mra[39m to the l[31maziest o[39mf them. E[31mlev[39men of
+them jumped up to claim it, so he gave it to the twelfth. this traveler was on
+the right lines. But in countries which do not enjoy Mediterranean sunshine
+idleness is more difficult, and a great public propaganda will be required to
+inaugurate it. I hope that, after reading the following pages, the leaders of
+[31mthe[39m [31mYMCA[39m [31mwill[39m [31mstart[39m [31ma[39m [31mcampaign[39m [31mto[39m in[31mduce[39m g[31mood[39m yo[31mung[39m men to do nothing. If so, I
+shall not have lived in vain.

--- a/test/custom-length.js
+++ b/test/custom-length.js
@@ -1,0 +1,43 @@
+var fs = require('fs');
+var path = require('path');
+
+var strip = require('strip-ansi');
+var test = require('tape');
+
+var lib = require('../');
+
+var file = fs.readFileSync(path.join(__dirname, 'ansi-colored.txt'), 'utf8');
+
+test('can use custom length function', function (t) {
+    var wrap = lib({
+        start: 0,
+        stop: 80,
+        lengthFn: lengthFn
+    });
+
+    var wrapped = wrap(file.split('\n').join(' '));
+    var control = strip(file);
+
+    var wrappedLines = wrapped.split('\n');
+    var controlLines = control.split('\n');
+
+    t.equal(
+        wrappedLines.length,
+        controlLines.length,
+        'should contain the same number of lines'
+    );
+
+    for (var i = 0; i < wrappedLines.length; ++i) {
+        t.equal(
+            strip(wrappedLines[i]).length,
+            controlLines[i].length,
+            'each line should be equal'
+        );
+    }
+
+    t.end();
+})
+
+function lengthFn (chunk) {
+    return strip(chunk).length;
+}


### PR DESCRIPTION
(resubmitted without the accidential devDep...)

This PR allows you to pass a custom function for determining the length of a string; this allows you to ignore undesired characters (using something like [strip-ansi](https://www.npmjs.com/package/strip-ansi)) or to calculate double-width characters, if necessary.

Tests are included; I also updated the test runner to `tape` since `expresso` doesn't seem supported any longer, but I can leave that as-is and resubmit if you'd prefer.

I'm also fine with just releasing this as a different module if you're not looking to make any changes here, but figured I'd PR first and see what you thought.

Thanks!