### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
     "name": "James Halliday",
     "email": "mail@substack.net",
     "url": "http://substack.net"
-  }
+  },
+  "files": [
+    "examples",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
The readme and license files will be added by npm regardless of the `files` setting.
